### PR TITLE
Diagnostics Bug Fix, Enhancement, code clean up

### DIFF
--- a/ai-compile/vscode-extension/package.json
+++ b/ai-compile/vscode-extension/package.json
@@ -17,6 +17,10 @@
 	"contributes": {
 		"commands": [
 			{
+				"title": "Toggle Diagnostic Level",
+				"command": "python-hints.toggleDiagnosticLevel"
+			},
+			{
 				"title": "Toggle Diagnostics",
 				"command": "python-hints.toggleHints",
 				"icon": {
@@ -44,6 +48,12 @@
 			}
 		],
 		"keybindings": [
+			{
+				"command": "python-hints.toggleDiagnosticLevel",
+				"key": "ctrl+shift+t",
+				"mac": "ctrl+shift+t",
+				"when": "editorTextFocus"
+			},
 			{
 				"command": "python-hints.toggleHints",
 				"key": "ctrl+f1",

--- a/ai-compile/vscode-extension/src/codeActionProvider.ts
+++ b/ai-compile/vscode-extension/src/codeActionProvider.ts
@@ -88,10 +88,10 @@ export class EduCodeActionProvider implements vscode.CodeActionProvider {
         .get("enableDiagnostics", true) &&
         fileExt === "py"
       ) {
-        const diagnosticLevel: number = vscode.workspace
+
+        this.feedbackLevel = vscode.workspace
         .getConfiguration("python-hints")
         .get("diagnosticLevel", 0);
-        console.log(diagnosticLevel);
 
         let diagnostics: {
           code: string;

--- a/ai-compile/vscode-extension/src/decorator.ts
+++ b/ai-compile/vscode-extension/src/decorator.ts
@@ -114,15 +114,12 @@ export class Decorator {
     const deleteHighlights: vscode.DecorationOptions[] = [];
     const replaceHighlights: vscode.DecorationOptions[] = [];
 
-    const diagnosticLevel: number = vscode.workspace
-      .getConfiguration("python-hints")
-      .get("diagnosticLevel", 0);
-
-    const decoratorFlag: number = vscode.workspace
+    const activeHighlight: number = vscode.workspace
       .getConfiguration("python-hints")
       .get("activeHighlight", 0);
-    // console.log( "Updating decorations: " + flag );
-    if (decoratorFlag > 0) {
+    
+    if (activeHighlight !== 0) {
+
       const fixes: pymacer.Fixes = docStore.get(filePath)?.fixes;
       fixes?.forEach((fix) => {
         const position = new vscode.Position(fix.lineNo, 0);
@@ -130,23 +127,17 @@ export class Decorator {
           position,
           new RegExp(this.regEx)
         );
+
         let diagnosticMsg: string = "";
-        switch (diagnosticLevel) {
+
+        switch (activeHighlight) {
           case 1: {
             diagnosticMsg = fix.feedback[0].fullText;
             break;
           }
           case 2: {
-            diagnosticMsg = fix.repairClasses[0];
+            diagnosticMsg = fix.editDiffs[0].type.toUpperCase();
             break;
-          }
-          case 3: {
-            diagnosticMsg = fix.feedback[0].fullText;
-            break;
-          }
-          case 4: {
-            // already available in codelens
-            diagnosticMsg = fix.repairLine[0];
           }
         }
 
@@ -179,7 +170,7 @@ export class Decorator {
       });
     }
 
-    if (diagnosticLevel < 3) {
+    if (activeHighlight < 2) {
       activeEditor.setDecorations(this.decorationType, highlights);
       activeEditor.setDecorations(this.insertDecorationType, []);
       activeEditor.setDecorations(this.deleteDecorationType, []);

--- a/ai-compile/vscode-extension/src/extension.ts
+++ b/ai-compile/vscode-extension/src/extension.ts
@@ -115,6 +115,19 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
+  disposables.push(
+    vscode.commands.registerCommand(
+      "python-hints.toggleDiagnosticLevel",
+      async function () {
+        let diagnosticLevel: number = vscode.workspace
+          .getConfiguration("python-hints")
+          .get("diagnosticLevel", 0);
+          diagnosticLevel = (diagnosticLevel + 1) % 2;
+        vscode.workspace
+          .getConfiguration("python-hints")
+          .update("diagnosticLevel", diagnosticLevel, true);
+      }));
+
   decorator.registerDecorator(context);
 
   eventDisposables.push(


### PR DESCRIPTION
Fixed Bug: 
Multiple edits on same line displayed same error feedback as the first edit in the line

Enhacement: 
Added command for toggling diagnosticLevel
Segregated functionality of diagnosticLevel and activeHighlight to apply to code action diagnostics and code decorations respectively

Removed unused lines of code